### PR TITLE
Fix python package release so that the initial Django migration file is available.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     packages=['django_single_table_db_storage'],
     package_dir={'django_single_table_db_storage': 'django_single_table_db_storage'},
     package_data={},
+    include_package_data=True,
     scripts=[],
     install_requires=[
           'Django>=3.2',


### PR DESCRIPTION
It looks like the python package in the pypi does not have `migrations/0001_initial.py`.  :disappointed: 

Sorry about that. This will fix the problem in the next release.

Users were probably getting by in one of two ways as a workaround:

1. installing the package from github git repo, where all files are included.
2. regenerating the migration file.
   * if you did this, then you will need run a ghost migration to skip over this one that may look new to you.