### PR TITLE
fix problem where `pip install` doesn't install migrations. issue #3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "Framework :: Django :: 3.2",
     ],
     keywords="django storage database",
-    packages=['django_single_table_db_storage'],
+    packages=['django_single_table_db_storage', 'django_single_table_db_storage.migrations'],
     package_dir={'django_single_table_db_storage': 'django_single_table_db_storage'},
     package_data={},
     include_package_data=True,


### PR DESCRIPTION
Fixes https://github.com/waterimp/django-single-table-db-storage/issues/3

