### PR TITLE
prevent creation of new migrations when default_auto_field has changed

### DIFF
--- a/django_single_table_db_storage/apps.py
+++ b/django_single_table_db_storage/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class MyAppConfig(AppConfig):
+    name = 'django_single_table_db_storage'
+    default_auto_field = 'django.db.models.AutoField'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="django-single-table-db-storage",
-    version="0.1.3",
+    version="0.1.4",
     description="Provides a Django storage implementation that uses a single database table.",
     long_description=longdesc,
     long_description_content_type="text/markdown",
@@ -26,14 +26,16 @@ setup(
         "Framework :: Django :: 3.2",
     ],
     keywords="django storage database",
-    packages=['django_single_table_db_storage', 'django_single_table_db_storage.migrations'],
-    package_dir={'django_single_table_db_storage': 'django_single_table_db_storage'},
+    packages=['django_single_table_db_storage',
+              'django_single_table_db_storage.migrations'],
+    package_dir={
+        'django_single_table_db_storage': 'django_single_table_db_storage'},
     package_data={},
     include_package_data=True,
     scripts=[],
     install_requires=[
-          'Django>=3.2',
-          'django-extensions>=3.2',
-      ],
+        'Django>=3.2',
+        'django-extensions>=3.2',
+    ],
     python_requires=">=3.5",
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="django-single-table-db-storage",
-    version="0.1.4",
+    version="0.1.3",
     description="Provides a Django storage implementation that uses a single database table.",
     long_description=longdesc,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="django-single-table-db-storage",
-    version="0.1.3",
+    version="0.1.4",
     description="Provides a Django storage implementation that uses a single database table.",
     long_description=longdesc,
     long_description_content_type="text/markdown",
@@ -26,16 +26,14 @@ setup(
         "Framework :: Django :: 3.2",
     ],
     keywords="django storage database",
-    packages=['django_single_table_db_storage',
-              'django_single_table_db_storage.migrations'],
-    package_dir={
-        'django_single_table_db_storage': 'django_single_table_db_storage'},
+    packages=['django_single_table_db_storage', 'django_single_table_db_storage.migrations'],
+    package_dir={'django_single_table_db_storage': 'django_single_table_db_storage'},
     package_data={},
     include_package_data=True,
     scripts=[],
     install_requires=[
-        'Django>=3.2',
-        'django-extensions>=3.2',
-    ],
+          'Django>=3.2',
+          'django-extensions>=3.2',
+      ],
     python_requires=">=3.5",
 )


### PR DESCRIPTION
On newer installations of django `DEFAULT_AUTO_FIELD` defaults to `BigAutoField`. When you install django-single-table-db-storage and run `makemigrations`, it creates a `0002_blahblah.py` migration in your venv.

This PR creates an `AppConfig` for the library overriding the django-wide `DEFAULT_AUTO_FIELD` to match the one in the existing migration.